### PR TITLE
add link from collection verse cards

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,7 +7,9 @@ export default defineSchema({
     userId: v.string(),
   }),
   collectionVerses: defineTable({
+    bibleId: v.string(),
     verseId: v.string(),
+    chapterId: v.string(),
     verseText: v.string(),
     collectionId: v.id("collections"),
   }).index("by_collection_id", ["collectionId"]),

--- a/convex/verseCollections.ts
+++ b/convex/verseCollections.ts
@@ -8,6 +8,8 @@ export const addVerseToCollection = mutation({
         collectionId: v.id("collections"),
         userId: v.string(),
         verseText: v.string(),
+        chapterId: v.string(),
+        bibleId: v.string(),
     },
     handler: async (ctx, args) => {
         await validateCollectionAccess(ctx, args.collectionId, args.userId);
@@ -16,6 +18,8 @@ export const addVerseToCollection = mutation({
             verseId: args.verseId,
             verseText: args.verseText,
             collectionId: args.collectionId,
+            chapterId: args.chapterId,
+            bibleId: args.bibleId,
         });
     }
 });

--- a/src/components/bible/add-to-collection-dialog.tsx
+++ b/src/components/bible/add-to-collection-dialog.tsx
@@ -21,10 +21,12 @@ import { ScrollArea } from '../ui/scroll-area'
 type Props = {
     verseText: string
     verseId: string
+    chapterId: string
+    bibleId: string
     trigger: React.ReactNode
 }
 
-const AddToCollectionDialog = ({ verseText, verseId, trigger }: Props) => {
+const AddToCollectionDialog = ({ verseText, verseId, trigger, chapterId, bibleId }: Props) => {
     const { data: session } = useSession()
     const [loadingCollectionId, setLoadingCollectionId] = useState<string | null>(null)
     const { mutate: addVerseToCollection, isPending: isAddingVerseToCollection } = useAddVerseToCollection()
@@ -42,7 +44,9 @@ const AddToCollectionDialog = ({ verseText, verseId, trigger }: Props) => {
             verseId,
             collectionId,
             userId: session.session.userId,
-            verseText
+            verseText,
+            chapterId,
+            bibleId
         }, {
             onSettled: () => {
                 setLoadingCollectionId(null)

--- a/src/components/collections/collection-verse-card.tsx
+++ b/src/components/collections/collection-verse-card.tsx
@@ -1,20 +1,35 @@
-import { Id } from "convex/_generated/dataModel"
-import DeleteVerseColButton from "./delete-verse-collection-btn"
+import { Link } from "@tanstack/react-router";
+import { Id } from "convex/_generated/dataModel";
+import DeleteVerseColButton from "./delete-verse-collection-btn";
 
-const CollectionVerseCard = ({ verseCollectionId, collectionId, userId, verseText, verseId }: { verseCollectionId: Id<'collectionVerses'>, collectionId: Id<'collections'>, userId: string, verseText: string, verseId: string }) => {
+type Props = {
+    _id: Id<"collectionVerses">;
+    _creationTime: number;
+    verseId: string;
+    bibleId: string;
+    chapterId: string;
+    verseText: string;
+    collectionId: Id<"collections">;
+    userId: string;
+}
+
+
+const CollectionVerseCard = ({ _id, verseId, bibleId, chapterId, verseText, collectionId, userId }: Props) => {
     return (
         <div
             className="p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors relative group"
         >
-            <DeleteVerseColButton verseCollectionId={verseCollectionId} collectionId={collectionId} userId={userId} />
+            <DeleteVerseColButton verseCollectionId={_id} collectionId={collectionId} userId={userId} />
             <div className="flex items-start gap-3">
                 <div className="flex-1">
                     <p className="text-base sm:text-lg leading-relaxed text-foreground max-w-2xl">
                         {verseText}
                     </p>
-                    <p className="mt-4 text-xs text-muted-foreground">
-                        {verseId}
-                    </p>
+                    <Link className="hover:underline" to={'/bible'} search={{ bible: bibleId, chapter: chapterId, verse: verseId }}>
+                        <p className="mt-4 text-xs text-muted-foreground">
+                            {verseId}
+                        </p>
+                    </Link>
                 </div>
             </div>
         </div>

--- a/src/components/search/search-verse-card.tsx
+++ b/src/components/search/search-verse-card.tsx
@@ -11,6 +11,7 @@ type VerseCardProps = {
 }
 
 const SearchVerseCard = ({ verse, query }: VerseCardProps) => {
+    console.log(verse)
     return (
         <div
             className="mb-4 sm:mb-6 p-3 sm:p-4 rounded-lg border bg-card hover:bg-accent/50 transition-colors"
@@ -26,6 +27,8 @@ const SearchVerseCard = ({ verse, query }: VerseCardProps) => {
                         <AddToCollectionDialog
                             verseText={verse.text.trim()}
                             verseId={verse.id}
+                            chapterId={verse.chapterId}
+                            bibleId={verse.bibleId}
                             trigger={
                                 <Button
                                     variant={'ghost'}

--- a/src/lib/parse.tsx
+++ b/src/lib/parse.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils';
 import parse, { Element, Text } from 'html-react-parser';
 import { BookmarkPlus } from 'lucide-react';
 
-export function parseBible(content: string, highlightSid?: string) {
+export function parseBible(content: string, highlightSid?: string, bibleId?: string, chapterId?: string) {
   return parse(content ?? '', {
     replace: (domNode) => {
       if (domNode.type === 'tag' && domNode.name === 'span' && domNode.attribs?.class?.split(' ').includes('v')) {
@@ -25,6 +25,8 @@ export function parseBible(content: string, highlightSid?: string) {
             <AddToCollectionDialog
               verseText={verseNumber.data}
               verseId={element.attribs['data-sid']}
+              chapterId={element.attribs['data-chapter']}
+              bibleId={element.attribs['data-bible']}
               trigger={
                 <button
                   className={cn(
@@ -62,6 +64,7 @@ export function parseBible(content: string, highlightSid?: string) {
           <div className="space-y-4">
             {verses.map((verse, index) => {
               const isHighlighted = highlightSid && verse.id === highlightSid;
+
               return (
                 <p
                   key={index}
@@ -78,6 +81,8 @@ export function parseBible(content: string, highlightSid?: string) {
                       {verse.number}
                     </span>
                     <AddToCollectionDialog
+                      chapterId={chapterId ?? ''}
+                      bibleId={bibleId ?? ''}
                       verseText={verse.text.trim()}
                       verseId={verse.id}
                       trigger={

--- a/src/routes/_authed/collections/$collectionId.tsx
+++ b/src/routes/_authed/collections/$collectionId.tsx
@@ -60,7 +60,7 @@ function RouteComponent() {
           <div className="w-full max-w-3xl">
             <div className="space-y-6">
               {verses.map((verse) => (
-                <CollectionVerseCard key={verse._id} verseCollectionId={verse._id} collectionId={collection._id} userId={userId} verseText={verse.verseText} verseId={verse.verseId} />
+                <CollectionVerseCard key={verse._id} {...verse} userId={userId} />
               ))}
             </div>
           </div>

--- a/src/routes/bible.tsx
+++ b/src/routes/bible.tsx
@@ -69,7 +69,7 @@ function RouteComponent() {
             </Link>
           </div>}
           <div className="mt-4 prose prose-lg max-w-none prose-p:leading-relaxed prose-p:text-base sm:prose-p:text-lg prose-headings:scroll-mt-20">
-            {bible && chapter ? parseBible(chapterData?.content ?? '', highlightSid) : <div className='flex items-center justify-center h-full text-center'>
+            {bible && chapter ? parseBible(chapterData?.content ?? '', highlightSid, bible, chapter) : <div className='flex items-center justify-center h-full text-center'>
               Select a Bible and Chapter to view the content
             </div>}
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for storing and displaying Bible and chapter identifiers when adding verses to collections.
  - Verse cards in collections now allow navigation to the specific Bible chapter and verse via clickable links.
- **Improvements**
  - Enhanced dialogs and components to handle and display additional context (Bible and chapter) when adding verses to collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->